### PR TITLE
Add configurable RSA sign salt length

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ The following environment variables can be set to configure LKMS.
 - **KMS_DATA_PATH**: Path LKMS will put its database.
 	- Docker default: `/data`
 	- Native default: `/tmp/local-kms`
+- **KMS_RSA_SIGN_SALT_LENGTH**: Controls the length of the salt used in the PSS signature. It can either be a positive number of bytes, or one of the special cases:
+  - 0 - **default** - causes the salt in a PSS signature to be as large as possible when signing, and to be auto-detected when verifying.
+  - -1 - causes the salt length to equal the length of the hash used in the signature.
 
 Warning: keys and aliases are stored under their ARN, thus their identity includes both KMS_ACCOUNT_ID and KMS_REGION. Changing these values will make pre-existing data inaccessible.
 

--- a/src/cmk/rsa_key.go
+++ b/src/cmk/rsa_key.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"github.com/nsmithuk/local-kms/src/config"
 )
 
 type RsaPrivateKey rsa.PrivateKey
@@ -146,7 +147,9 @@ func (k *RsaKey) Sign(digest []byte, algorithm SigningAlgorithm) ([]byte, error)
 	switch algorithm {
 	case SigningAlgorithmRsaPssSha256, SigningAlgorithmRsaPssSha384, SigningAlgorithmRsaPssSha512:
 
-		return rsa.SignPSS(rand.Reader, &key, hash, digest, nil)
+		return rsa.SignPSS(rand.Reader, &key, hash, digest, &rsa.PSSOptions{
+			SaltLength: config.RsaSignSaltLength,
+		})
 
 	case SigningAlgorithmRsaPkcsSha256, SigningAlgorithmRsaPkcsSha384, SigningAlgorithmRsaPkcsSha512:
 
@@ -218,9 +221,9 @@ func (k *RsaKey) HashAndVerify(signature []byte, message []byte, algorithm Signi
 	return k.Verify(signature, digest, algorithm)
 }
 
-//----------------------------------------------------
+// ----------------------------------------------------
 // Construct key from YAML (seeding)
-//---
+// ---
 func (k *RsaKey) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// Cannot use embedded 'Key' struct

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,6 +5,7 @@ import "strings"
 var AWSRegion string
 var AWSAccountId string
 var DatabasePath string
+var RsaSignSaltLength int
 
 func ArnPrefix() string {
 	return "arn:aws:kms:" + AWSRegion + ":" + AWSAccountId + ":"

--- a/start.go
+++ b/start.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 var (
@@ -81,6 +82,22 @@ func main() {
 	}
 
 	config.DatabasePath, _ = filepath.Abs(dataPath)
+
+	//-------------------------------
+	// KMS RSA Sign salt length
+
+	saltLength := os.Getenv("KMS_RSA_SIGN_SALT_LENGTH")
+
+	if saltLength == "" {
+		saltLength = "0"
+	}
+
+	atoi, err := strconv.Atoi(saltLength)
+	if err != nil {
+		logger.Fatalf("Invalid RSA sign salt length: %s", saltLength)
+	}
+
+	config.RsaSignSaltLength = atoi
 
 	//-------------------------------
 	// Seed


### PR DESCRIPTION
Introduce KMS_RSA_SIGN_SALT_LENGTH environment variable to control the salt length used in PSS signatures. This allows users to specify custom salt lengths or use default values.